### PR TITLE
Block pings in C09BQEC01FZ with fun rejection message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,14 @@ async function pingCommand(
   const { text: message } = payload;
 
   try {
+    if (channelId === "C09BQEC01FZ") {
+      await respond({
+        text: `<@${userId}> tried to ping. i'm tired boss. no pings for you.`,
+        response_type: "in_channel",
+      });
+      return;
+    }
+
     if (!(await hasPerms(userId, channelId, client))) {
       await respond({
         text: stripIndents`


### PR DESCRIPTION
When someone tries to use /channel or /here in C09BQEC01FZ, respond with a rejection message using the default bot avatar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified ping command to reject execution in a designated channel with a custom response message instead of processing the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->